### PR TITLE
Added config to run cuckoo as a cli command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@guidesmiths/cuckoojs",
   "version": "0.0.1",
   "description": "CuckooJS CLI",
+  "keywords": [
+    "schematics nestjs"
+  ],
+  "license": "MIT",
+  "main": "./build/src/cli/cli.js",
+  "bin": {
+    "cuckoo": "./build/src/cli/cli.js"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node build/src/cli/cli.js",
@@ -9,9 +17,6 @@
     "lint": "eslint --ext .ts .",
     "lint:fix": "eslint --fix --ext .ts ."
   },
-  "keywords": [
-    "schematics nestjs"
-  ],
   "contributors": [
     {
       "name": "David Yusta",
@@ -20,15 +25,16 @@
     {
       "name": "Laura Corbí",
       "email": "laura.corbi@one-beyond.com"
-    },    {
+    },
+    {
       "name": "Adrián Rodríguez",
       "email": "adrian.rodriguez@one-beyond.com"
-    },    {
+    },
+    {
       "name": "Íñigo Marquínez",
       "email": "inigo.marquinez@one-beyond.com"
     }
   ],
-  "license": "MIT",
   "dependencies": {
     "@angular-devkit/schematics-cli": "^14.2.3",
     "@nestjs/schematics": "^9.0.3",

--- a/src/cli/lib/ui/ui.ts
+++ b/src/cli/lib/ui/ui.ts
@@ -1,3 +1,5 @@
+import {version} from '../../../../package.json';
+
 export const messages: Record<string, string> = {
 	banner: `
    _____           _                    _  _____ 
@@ -5,7 +7,7 @@ export const messages: Record<string, string> = {
  | |    _   _  ___| | _____   ___      | | (___  
  | |   | | | |/ __| |/ / _ \\ / _ \\ _   | |\\___ \\ 
  | |___| |_| | (__|   < (_) | (_) | |__| |____) |
-  \\_____\\__,_|\\___|_|\\_\\___/ \\___/ \\____/|_____/ 
+  \\_____\\__,_|\\___|_|\\_\\___/ \\___/ \\____/|_____/ v${version}
                                                                            
 		`,
 };


### PR DESCRIPTION
### Main changes

- :new: added config to run cuckoo as a cli command
- :wrench: show version number in banner

Now we can run CuckooJS from the terminal by running

`cuckoo new <app_name>`

after linking it locally with `npm link`

### Context

- 🎫 Closes https://dev.azure.com/onebeyondinternal/Chapter.Spain.Node/_sprints/taskboard/Chapter.Spain.Node%20Team/Chapter.Spain.Node/2022%20Q4?workitem=296