### PR TITLE
Added new command to bypass generating Nest elements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,15 +13,14 @@
                 "*.ts",
                 "*.tsx"
             ],
-          "rules": {
-            "@typescript-eslint/no-extraneous-class": "off"
-          }
+            "rules": {
+                "@typescript-eslint/no-extraneous-class": "off"
+            }
         }
     ],
     "parserOptions": {
         "ecmaVersion": "latest",
         "sourceType": "module"
     },
-    "rules": {
-    }
+    "rules": {}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Outputs
 src/**/*.js
 src/**/*.js.map

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-
 # Ignores TypeScript files, but keeps definitions.
 *.ts
 !*.d.ts

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 DCSL GuideSmiths
+Copyright (c) 2022 One Beyond
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,29 +1,41 @@
 #!/usr/bin/env node
 import {Command} from 'commander';
 import {version} from '../../package.json';
-import {NewCommand} from './commands/new.command';
+import {NewCommand, GenerateCommand} from './commands';
 
-const init = () => {
-	const program = new Command('cuckoo');
+const init = (): void => {
+	const cuckoo = new Command('cuckoo');
 
-	program
+	cuckoo
 		.version(
 			version,
 			'-v, --version',
-			'output the current version',
-		)
-		.helpOption('-h, --help', 'output usage information')
-		.showHelpAfterError()
-		.usage('<command> [options]')
+			'Output the current version.',
+		);
 
+	cuckoo
+		.helpOption('-h, --help', 'Output usage information.')
+		.showHelpAfterError()
+		.usage('<command> [options]');
+
+	cuckoo
 		.command('new <name>')
 		.alias('n')
-		.description('generate a new NestJS project scaffolding')
+		.description('Generate Nest application with basic tooling.')
 		.action(async (name: string, _options: any) => {
 			await new NewCommand(name).execute();
 		});
 
-	program.parse(process.argv);
+	cuckoo
+		.command('generate <schematic> <name> [options...]')
+		.alias('g')
+		.description('Generate a Nest element.')
+		.action(async (schematic: string, name: string, options: string[]) => {
+			await new GenerateCommand(schematic, name, options).execute();
+		});
+
+	cuckoo
+		.parse(process.argv);
 };
 
 init();

--- a/src/cli/commands/abstract.command.ts
+++ b/src/cli/commands/abstract.command.ts
@@ -1,0 +1,12 @@
+import Printer from '../lib/printer/printer';
+
+export class AbstractCommand {
+	protected static endProcess(status: number) {
+		process.exit(status);
+	}
+
+	protected printSuccess = Printer.format({fontColor: 'green', decoration: 'bold'});
+	protected printError = Printer.format({fontColor: 'red', decoration: 'bold'});
+	protected printNeutral = Printer.format({decoration: 'bold'});
+}
+

--- a/src/cli/commands/generate.command.ts
+++ b/src/cli/commands/generate.command.ts
@@ -1,0 +1,28 @@
+import {SchematicRunner} from '../lib/runners/schematic.runner';
+import {messages} from '../lib/ui/ui';
+import {AbstractCommand} from './abstract.command';
+
+export class GenerateCommand extends AbstractCommand {
+	private readonly schematicRunner: SchematicRunner = new SchematicRunner();
+
+	constructor(
+		private readonly schematic: string,
+		private readonly name: string,
+		private readonly options: string[],
+	) {
+		super();
+	}
+
+	public async execute() {
+		this.printSuccess(messages.banner);
+
+		try {
+			this.printNeutral(`Generating Nest ${this.schematic}.`);
+			await this.schematicRunner.generateNestElement(this.schematic, this.name, this.options);
+			this.printSuccess(`Nest ${this.schematic} generated.`);
+		} catch (error: unknown) {
+			this.printError(`Error generating Nest ${this.schematic}: ${(error as Error).message}`);
+			GenerateCommand.endProcess(1);
+		}
+	}
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,0 +1,2 @@
+export {NewCommand} from './new.command';
+export {GenerateCommand} from './generate.command';

--- a/src/cli/commands/new.command.ts
+++ b/src/cli/commands/new.command.ts
@@ -8,12 +8,9 @@ import * as fs from 'fs';
 import {join} from 'path';
 import {BashRunner} from '../lib/runners/bash.runner';
 import {BashRunnerHusky} from '../lib/runners/bash.runner.husky';
+import {AbstractCommand} from './abstract.command';
 
-export class NewCommand {
-	private static endProcess(status: number) {
-		process.exit(status);
-	}
-
+export class NewCommand extends AbstractCommand {
 	private readonly initialPackages: PackageEntry[] = [
 		{name: 'husky', version: '^8.0.1', section: 'devDependencies'},
 		{name: '@commitlint/cli', version: '^17.1.2', section: 'devDependencies'},
@@ -33,7 +30,9 @@ export class NewCommand {
 		private readonly npmRunner: NpmRunner = new NpmRunner(),
 		private readonly bashRunner: BashRunner = new BashRunner(),
 		private readonly bashRunnerHusky: BashRunnerHusky = new BashRunnerHusky(),
-	) {}
+	) {
+		super();
+	}
 
 	public async execute() {
 		const printSuccess = Printer.format({fontColor: 'green', decoration: 'bold'});

--- a/src/cli/commands/new.command.ts
+++ b/src/cli/commands/new.command.ts
@@ -2,7 +2,6 @@ import {SchematicRunner} from '../lib/runners/schematic.runner';
 import {GitRunner} from '../lib/runners/git.runner';
 import type {PackageEntry, ScriptEntry} from '../lib/runners/npm.runner';
 import {NpmRunner} from '../lib/runners/npm.runner';
-import Printer from '../lib/printer/printer';
 import {messages} from '../lib/ui/ui';
 import * as fs from 'fs';
 import {join} from 'path';
@@ -11,6 +10,12 @@ import {BashRunnerHusky} from '../lib/runners/bash.runner.husky';
 import {AbstractCommand} from './abstract.command';
 
 export class NewCommand extends AbstractCommand {
+	private readonly schematicRunner: SchematicRunner = new SchematicRunner();
+	private readonly gitRunner: GitRunner = new GitRunner();
+	private readonly npmRunner: NpmRunner = new NpmRunner();
+	private readonly bashRunner: BashRunner = new BashRunner();
+	private readonly bashRunnerHusky: BashRunnerHusky = new BashRunnerHusky();
+
 	private readonly initialPackages: PackageEntry[] = [
 		{name: 'husky', version: '^8.0.1', section: 'devDependencies'},
 		{name: '@commitlint/cli', version: '^17.1.2', section: 'devDependencies'},
@@ -24,56 +29,47 @@ export class NewCommand extends AbstractCommand {
 	];
 
 	constructor(
-		private readonly name: string,
-		private readonly schematicRunner: SchematicRunner = new SchematicRunner(),
-		private readonly gitRunner: GitRunner = new GitRunner(),
-		private readonly npmRunner: NpmRunner = new NpmRunner(),
-		private readonly bashRunner: BashRunner = new BashRunner(),
-		private readonly bashRunnerHusky: BashRunnerHusky = new BashRunnerHusky(),
+		private readonly name: string
 	) {
 		super();
 	}
 
 	public async execute() {
-		const printSuccess = Printer.format({fontColor: 'green', decoration: 'bold'});
-		const printError = Printer.format({fontColor: 'red', decoration: 'bold'});
-		const printNeutral = Printer.format({decoration: 'bold'});
-
-		printSuccess(messages.banner);
+		this.printSuccess(messages.banner);
 
 		if (this.checkFileExists()) {
-			printError(`Error generating new project: Folder ${this.name} already exists`);
+			this.printError(`Error generating new project: Folder ${this.name} already exists`);
 			NewCommand.endProcess(1);
 		}
 
 		try {
 			this.checkFileExists();
 
-			printNeutral('(1/7) Generating NestJS application scaffolding');
+			this.printNeutral('(1/7) Generating NestJS application scaffolding');
 			await this.schematicRunner.generateNestApplication(this.name);
 
-			printNeutral('(2/7) Initializing Git repository');
+			this.printNeutral('(2/7) Initializing Git repository');
 			await this.gitRunner.init({folderName: this.name});
 
-			printNeutral('(3/7) Adding additional packages');
+			this.printNeutral('(3/7) Adding additional packages');
 			await this.npmRunner.addPackages(this.name, this.initialPackages);
 
-			printNeutral('(4/7) Adding additional npm scripts');
+			this.printNeutral('(4/7) Adding additional npm scripts');
 			await this.npmRunner.addScripts(this.name, this.initialScripts);
 
-			printNeutral('(5/7) Creating commitlint config');
+			this.printNeutral('(5/7) Creating commitlint config');
 			await this.bashRunner.runCommand(this.name);
 
-			printNeutral('(6/7) Installing dependencies');
+			this.printNeutral('(6/7) Installing dependencies');
 			await this.npmRunner.install(this.name);
 
-			printNeutral('(7/7) Creating husky files');
+			this.printNeutral('(7/7) Creating husky files');
 			await this.bashRunnerHusky.runHuskyCommit(this.name);
 
-			printSuccess(`NestJS application "${this.name}" generated`);
-			printSuccess('Thanks for using CuckooJS');
+			this.printSuccess(`NestJS application "${this.name}" generated`);
+			this.printSuccess('Thanks for using CuckooJS');
 		} catch (error: unknown) {
-			printError(`Error generating new project: ${(error as Error).message}`);
+			this.printError(`Error generating new project: ${(error as Error).message}`);
 			this.removeFolder();
 			NewCommand.endProcess(1);
 		}

--- a/src/cli/lib/runners/generic.runner.ts
+++ b/src/cli/lib/runners/generic.runner.ts
@@ -11,7 +11,7 @@ export class GenericRunner {
 	): Promise<string | void> {
 		const options: SpawnOptions = {
 			cwd,
-			stdio: 'pipe',
+			stdio: 'inherit',
 			shell: true,
 		};
 

--- a/src/cli/lib/runners/schematic.runner.ts
+++ b/src/cli/lib/runners/schematic.runner.ts
@@ -16,4 +16,9 @@ export class SchematicRunner extends GenericRunner {
 		const args = ['@nestjs/schematics:application', `--name ${name}`];
 		await super.run(SchematicRunner.getSchematicPath(), args);
 	}
+
+	public async generateNestElement(schematic: string, name: string, options: string[]) {
+		const args = [`@nestjs/schematics:${schematic} ${name} ${options.join(' ')}`];
+		await super.run(SchematicRunner.getSchematicPath(), args);
+	}
 }


### PR DESCRIPTION
### Main changes

- chore: minor style fixes
- fix: generic runner options to show executed command output
- refactor: added AbstractCommand for generic members and functions
- feat: added GenerateCommand to generate new Nest elements
- feat: added new options to the CLI

### Context

- Closes https://dev.azure.com/onebeyondinternal/Chapter.Spain.Node/_sprints/taskboard/Chapter.Spain.Node%20Team/Chapter.Spain.Node/2022%20Q4?workitem=305